### PR TITLE
Fixed AddLine() to write the line in the debug msg

### DIFF
--- a/src/LogentriesCore/AsyncLogger.cs
+++ b/src/LogentriesCore/AsyncLogger.cs
@@ -596,7 +596,7 @@ namespace LogentriesCore.Net
 
         public virtual void AddLine(string line)
         {
-            WriteDebugMessages("LE - Adding Line: line");
+            WriteDebugMessages("LE - Adding Line: " + line);
             if (!IsRunning)
             {
                 // We need to load user credentials only

--- a/src/LogentriesCore/AsyncLogger.cs
+++ b/src/LogentriesCore/AsyncLogger.cs
@@ -596,7 +596,7 @@ namespace LogentriesCore.Net
 
         public virtual void AddLine(string line)
         {
-            WriteDebugMessages("LE - Adding Line: " + line);
+            WriteDebugMessages("Adding Line: " + line);
             if (!IsRunning)
             {
                 // We need to load user credentials only


### PR DESCRIPTION
Before the debug message for each line was:  "LE: LE - Adding Line: line" which doesn't make much sense to me...
This fixes the call to WriteDebugMessages()