### PR TITLE
Update Microsoft.WindowsAzure.ConfigurationManager Version.

### DIFF
--- a/src/LogentriesCore/AsyncLogger.cs
+++ b/src/LogentriesCore/AsyncLogger.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Collections.Concurrent;
+using System.Collections;
 using System.Configuration;
 using System.Diagnostics;
 using System.IO;
@@ -9,14 +9,15 @@ using System.Threading;
 using System.Text.RegularExpressions;
 
 #if NET4_0
-using Microsoft.WindowsAzure;
+    using Microsoft.Azure;
 #endif
 
 namespace LogentriesCore.Net
 {
     using System.Security;
-    using Microsoft.WindowsAzure;
-
+    using System.Collections.Concurrent;
+    using Microsoft.Azure;
+    
     public class AsyncLogger
     {
         #region Constants

--- a/src/LogentriesCore/LogentriesCore.csproj
+++ b/src/LogentriesCore/LogentriesCore.csproj
@@ -31,8 +31,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.WindowsAzure.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.2.0.3\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
+    <Reference Include="Microsoft.WindowsAzure.Configuration, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.3.1.0\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />

--- a/src/LogentriesCore/packages.config
+++ b/src/LogentriesCore/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.3" targetFramework="net40" />
+  <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net40" />
 </packages>

--- a/src/packages/repositories.config
+++ b/src/packages/repositories.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <repositories>
   <repository path="..\LogentriesCore\packages.config" />
+  <repository path="..\LogentriesCore35\packages.config" />
   <repository path="..\LogentriesLog4net\packages.config" />
   <repository path="..\LogentriesNLog\packages.config" />
   <repository path="..\LogentriesNLog35\packages.config" />


### PR DESCRIPTION
Microsoft renamed Microsoft.WindowsAzure dll to Microsoft.Azure. News versions will require the new dll version, otherwise you will get error "Could not load type 'Microsoft.WindowsAzure.CloudConfigurationManager' from assembly 'Microsoft.WindowsAzure.Configuration, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.":"Microsoft.WindowsAzure.CloudConfigurationManager"