### PR TITLE
do not use CloudConfigurationManager under mono

### DIFF
--- a/src/LogentriesCore/AsyncLogger.cs
+++ b/src/LogentriesCore/AsyncLogger.cs
@@ -476,7 +476,18 @@ namespace LogentriesCore.Net
          */
         private string retrieveSetting(String name)
         {
-            var cloudconfig = CloudConfigurationManager.GetSetting(name);
+            string cloudconfig = null;
+            if (Environment.OSVersion.Platform == PlatformID.Unix)
+            {
+                cloudconfig = ConfigurationManager.AppSettings.Get(name);
+            }
+            else
+            {
+                cloudconfig = CloudConfigurationManager.GetSetting(name);
+            }
+
+
+            
             if (!String.IsNullOrWhiteSpace(cloudconfig))
             {
                 WriteDebugMessages(String.Format("Found Cloud Configuration settings for {0}", name));


### PR DESCRIPTION
Added environment check:
In case of mono - use plain old ConfigurationManager
In case of .net - use CloudConfigurationManager